### PR TITLE
Add support for static prop lump versions 12 and 13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>bspsrc</artifactId>
     <groupId>info.ata4.bspsrc</groupId>
     <packaging>jar</packaging>
-    <version>1.4.3-strata</version>
+    <version>1.4.3-strata2</version>
     <description>A Source engine map decompile</description>
     <url>https://github.com/ata4/bspsource</url>
 

--- a/src/main/java/info/ata4/bsplib/io/lumpreader/StaticPropLumpReader.java
+++ b/src/main/java/info/ata4/bsplib/io/lumpreader/StaticPropLumpReader.java
@@ -48,7 +48,7 @@ public class StaticPropLumpReader implements LumpReader<StaticPropLumpReader.Sta
 			dataReader.seek((long) psextra * PAD_SIZE, CURRENT);
 		}
 
-		List<Integer> staticPropLeafs = readLeafs(dataReader);
+		List<Number> staticPropLeafs = readLeafs(dataReader);
 
 		Map<Integer, Vector3f> scaling;
 		if (appId == VINDICTUS && sprpVersion > 5) {
@@ -82,11 +82,11 @@ public class StaticPropLumpReader implements LumpReader<StaticPropLumpReader.Sta
 		);
 	}
 
-	private List<Integer> readLeafs(DataReader reader) throws IOException {
+	private List<Number> readLeafs(DataReader reader) throws IOException {
 		int leaveCount = reader.readInt();
 		return DataReaderUtil.readChunks(
 				reader,
-				DataReader::readUnsignedShort,
+				sprpVersion >= 12 ? DataReader::readUnsignedInt : DataReader::readUnsignedShort,
 				leaveCount
 		);
 	}
@@ -187,6 +187,9 @@ public class StaticPropLumpReader implements LumpReader<StaticPropLumpReader.Sta
 			new StaticPropStructDescriptor(DStaticPropV10::new, 10),
 			new StaticPropStructDescriptor(DStaticPropV11lite::new, 11),
 			new StaticPropStructDescriptor(DStaticPropV11::new, 11),
+			// supposedly, v12 only changed static prop leafs. should parse the same as v11
+			new StaticPropStructDescriptor(DStaticPropV11::new, 12),
+			new StaticPropStructDescriptor(DStaticPropV13::new, 13),
 			new StaticPropStructDescriptor(DStaticPropV5Ship::new, 5, THE_SHIP),
 			new StaticPropStructDescriptor(DStaticPropV6BGT::new, 6, BLOODY_GOOD_TIME),
 			new StaticPropStructDescriptor(DStaticPropV7ZC::new, 7, ZENO_CLASH),
@@ -216,7 +219,7 @@ public class StaticPropLumpReader implements LumpReader<StaticPropLumpReader.Sta
 	public static class StaticPropData {
 
 		public final List<String> names;
-		public final List<Integer> leafs;
+		public final List<Number> leafs;
 		public final List<? extends DStaticProp> props;
 
 		public StaticPropData() {
@@ -225,7 +228,7 @@ public class StaticPropLumpReader implements LumpReader<StaticPropLumpReader.Sta
 
 		public StaticPropData(
 				List<String> names,
-				List<Integer> leafs,
+				List<Number> leafs,
 				List<? extends DStaticProp> props
 		) {
 			this.names = listCopyOf(names);

--- a/src/main/java/info/ata4/bsplib/struct/BspData.java
+++ b/src/main/java/info/ata4/bsplib/struct/BspData.java
@@ -61,7 +61,7 @@ public class BspData {
     public List<Integer> occluderVerts;
     public List<? extends Integer> surfEdges;
     public List<String> staticPropName;
-    public List<Integer> staticPropLeaf;
+    public List<Number> staticPropLeaf;
     public List<String> texnames;
     public Set<LevelFlag> mapFlags;
 

--- a/src/main/java/info/ata4/bsplib/struct/DStaticPropV10CSGO.java
+++ b/src/main/java/info/ata4/bsplib/struct/DStaticPropV10CSGO.java
@@ -21,7 +21,7 @@ import java.io.IOException;
  */
 public class DStaticPropV10CSGO extends DStaticPropV9 {
 
-    protected int unknown;
+    protected int flagsEx;
 
     @Override
     public int getSize() {
@@ -31,13 +31,13 @@ public class DStaticPropV10CSGO extends DStaticPropV9 {
     @Override
     public void read(DataReader in) throws IOException {
         super.read(in);
-        unknown = in.readInt();
+        flagsEx = in.readInt();
     }
 
     @Override
     public void write(DataWriter out) throws IOException {
         super.write(out);
-        out.writeInt(unknown);
+        out.writeInt(flagsEx);
     }
 
     /**

--- a/src/main/java/info/ata4/bsplib/struct/DStaticPropV13.java
+++ b/src/main/java/info/ata4/bsplib/struct/DStaticPropV13.java
@@ -1,0 +1,31 @@
+package info.ata4.bsplib.struct;
+
+import info.ata4.bsplib.vector.Vector3f;
+import info.ata4.io.DataReader;
+import info.ata4.io.DataWriter;
+
+import java.io.IOException;
+
+// Strata added non-uniform scaling, replacing the uniformScale member
+public class DStaticPropV13 extends DStaticPropV10CSGO {
+
+    public Vector3f scale;
+
+    @Override
+    public int getSize() {
+        return super.getSize() + 12; // 88
+    }
+
+    @Override
+    public void read(DataReader in) throws IOException
+    {
+        super.read(in);
+        scale = Vector3f.read(in);
+    }
+
+    @Override
+    public void write(DataWriter out) throws IOException {
+        super.write(out);
+        Vector3f.write(out, scale);
+    }
+}

--- a/src/main/java/info/ata4/bspsrc/BspSource.java
+++ b/src/main/java/info/ata4/bspsrc/BspSource.java
@@ -42,7 +42,7 @@ public class BspSource implements Runnable {
 
     private static final Logger L = LogUtils.getLogger();
 
-    public static final String VERSION = "1.4.3-Strata";
+    public static final String VERSION = "1.4.3-Strata2";
 
     private final BspSourceConfig config;
 

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -750,6 +750,10 @@ public class EntitySource extends ModuleDecompile {
             if (pst instanceof DStaticPropV11CSGO) {
                 writer.put("uniformscale", ((DStaticPropV11CSGO) pst).uniformScale);
             }
+            
+            if (pst instanceof DStaticPropV13) {
+                writer.put("scale", ((DStaticPropV13) pst).scale);
+            }
 
             writer.end("entity");
         }


### PR DESCRIPTION
Combined what @ozxybox informed me about what changed in v12 and v13 with what I could piece together from vbsp.exe in the P2:CE distribution. With these changes, I managed to parse maps from Portal: Revolution and modern Momentum Mod maps, so I'm assuming that this is correct.